### PR TITLE
Fix superagent from complaining about headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -297,9 +297,9 @@ var convertCookiesToAuthToken = function convertCookiesToAuthToken(apiOptions, c
         authorize: 'yes'
       };
 
-      headers['x-modhash'] = modhash;
+      var modhashedHeaders = _extends({}, headers, { 'x-modhash': modhash });
 
-      __WEBPACK_IMPORTED_MODULE_0_superagent___default.a.post(endpoint).set(headers).type('form').send(postParams).redirects(0).end(function (err, res) {
+      __WEBPACK_IMPORTED_MODULE_0_superagent___default.a.post(endpoint).set(modhashedHeaders).type('form').send(postParams).redirects(0).end(function (err, res) {
         if (res.status !== 302) {
           return resolve(res.status || 500);
         }

--- a/lib/api.es6.js
+++ b/lib/api.es6.js
@@ -227,11 +227,11 @@ const convertCookiesToAuthToken = (apiOptions, cookies) => {
           authorize: 'yes',
         };
 
-        headers['x-modhash'] = modhash;
+        const modhashedHeaders = { ...headers, 'x-modhash': modhash };
 
         superagent
           .post(endpoint)
-          .set(headers)
+          .set(modhashedHeaders)
           .type('form')
           .send(postParams)
           .redirects(0)

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@r/api-client": "3.x"
   },
   "devDependencies": {
-    "@r/build": "^0.0.9",
+    "@r/build": "^0.10.1",
     "babel-eslint": "^6.0.4",
     "eslint": "^2.8.0",
     "eslint-plugin-babel": "^3.2.0",


### PR DESCRIPTION
Superagent occasionly complains about trying to send
the 'x-modhash' header after the request has been sent.
This happens because the headers object is re-used,
but it's unclear what makes it only happen sometimes.
1X mweb had a similiar patch that fixed the issue:
https://github.com/reddit/reddit-mobile/commit/dea2f492e7df1726521028bb6e9cc34d3014f0b9

👓  @uzi && @nramadas 
