### PR TITLE
Add optional email scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ const myAppOptions = {
   ...APIOptions,
   clientSecret: 'my-client-secret'
   clientId: 'my-super-secret-app-id',
+  withEmailScope: false, // only supported for non-embedded apps
 };
 
 const token = await PrivateAPI.login(myAppOptions, username, password);

--- a/lib/api.es6.js
+++ b/lib/api.es6.js
@@ -233,10 +233,12 @@ const convertCookiesToAuthToken = (apiOptions, cookies, orderedHeaders, clientUs
         const clientId = apiOptions.clientId;
         const clientSecret = apiOptions.clientSecret;
 
+        const scope = SCOPES + (apiOptions.withEmailScope ? ',email' : '')
+
         const postParams = {
           client_id: clientId,
           redirect_uri,
-          scope: SCOPES,
+          scope,
           state: modhash,
           duration: 'permanent',
           authorize: 'yes',


### PR DESCRIPTION
👓  @schwers @dwick 

This adds the new email oauth scope. It's off by default so that we don't break embedded apps (mweb, desktop, etc), which are not allowed access to email, because they cannot keep a secret. Authorization would throw if email scope were requested for these apps.